### PR TITLE
:sparkles: Added support for checking for the existence of attachments

### DIFF
--- a/xcresultkittest/xcresultkittest/TestExecutor.swift
+++ b/xcresultkittest/xcresultkittest/TestExecutor.swift
@@ -183,15 +183,23 @@ class TestExecutor {
         print("Expected \(info.expectedSuccessfulTests) successful tests, and found them!")
         
         guard info.expectedFailedTests == testSummary.failedTests.count else {
-            print("Expected \(info.expectedFailedTests) successful tests, but found \(testSummary.failedTests.count)!")
+            print("Expected \(info.expectedFailedTests) failed tests, but found \(testSummary.failedTests.count)!")
             throw TestExecutorError.expectedFailure
         }
         print("Expected \(info.expectedFailedTests) failed tests, and found them!")
 
+        guard info.expectedExpectedFailedTests == testSummary.expectedFailureTests.count else {
+            print("Expected \(info.expectedExpectedFailedTests) expected failed tests, but found \(testSummary.expectedFailureTests.count)!")
+            throw TestExecutorError.expectedFailure
+        }
+        print("Expected \(info.expectedFailedTests) expected failed tests, and found them!")
+        
         guard info.expectedSkippedTests == testSummary.skippedTests.count else {
             print("Expected \(info.expectedSkippedTests) successful tests, but found \(testSummary.skippedTests.count)!")
             throw TestExecutorError.expectedFailure
         }
         print("Expected \(info.expectedSkippedTests) skipped tests, and found them!")
+        
+        print("Expected values match, overall test has passed!")
     }
 }

--- a/xcresultkittest/xcresultkittest/TestExecutor.swift
+++ b/xcresultkittest/xcresultkittest/TestExecutor.swift
@@ -200,6 +200,19 @@ class TestExecutor {
         }
         print("Expected \(info.expectedSkippedTests) skipped tests, and found them!")
         
+
+        var attachmentCount = 0
+        for details in testSummary.testDetails {
+            for asummary in details.activitySummaries {
+                attachmentCount += asummary.attachments.count
+            }
+        }
+        guard info.expectedAttachments == attachmentCount else {
+            print("Expected \(info.expectedAttachments) attachments, but found \(attachmentCount)!")
+            throw TestExecutorError.expectedFailure
+        }
+        print("Expected \(info.expectedAttachments) attachments, and found them!")
+        
         print("Expected values match, overall test has passed!")
     }
 }

--- a/xcresultkittest/xcresultkittest/TestInfo.swift
+++ b/xcresultkittest/xcresultkittest/TestInfo.swift
@@ -21,6 +21,7 @@ struct TestInfo {
     let expectedFailedTests: Int
     let expectedSkippedTests: Int
     let expectedExpectedFailedTests: Int
+    let expectedAttachments: Int
     
     func writeDetails(using file: DetailsFile) {
         file.writeLine(" Repo URL: \(repoURL)")
@@ -33,6 +34,7 @@ struct TestInfo {
         file.writeLine(" Expected Failed Tests: \(expectedFailedTests)")
         file.writeLine(" Expected Skipped Tests: \(expectedSkippedTests)")
         file.writeLine(" Expected Expected Failed Tests: \(expectedExpectedFailedTests)")
+        file.writeLine(" Expected Attachments: \(expectedAttachments)")
         file.writeLine(" ")
     }
 }

--- a/xcresultkittest/xcresultkittest/TestInfo.swift
+++ b/xcresultkittest/xcresultkittest/TestInfo.swift
@@ -20,6 +20,7 @@ struct TestInfo {
     let expectedSuccessfulTests: Int
     let expectedFailedTests: Int
     let expectedSkippedTests: Int
+    let expectedExpectedFailedTests: Int
     
     func writeDetails(using file: DetailsFile) {
         file.writeLine(" Repo URL: \(repoURL)")
@@ -31,6 +32,7 @@ struct TestInfo {
         file.writeLine(" Expected Successful Tests: \(expectedSuccessfulTests)")
         file.writeLine(" Expected Failed Tests: \(expectedFailedTests)")
         file.writeLine(" Expected Skipped Tests: \(expectedSkippedTests)")
+        file.writeLine(" Expected Expected Failed Tests: \(expectedExpectedFailedTests)")
         file.writeLine(" ")
     }
 }

--- a/xcresultkittest/xcresultkittest/TestSummary.swift
+++ b/xcresultkittest/xcresultkittest/TestSummary.swift
@@ -15,6 +15,7 @@ class TestSummary {
     var skippedTests: [ActionTestMetadata] = []
     var expectedFailureTests: [ActionTestMetadata] = []
     var failureMessages: [TestFailureIssueSummary] = []
+    var testDetails: [ActionTestSummary] = []
     
     func gatherSummary(from result: XCResultFile) {
         
@@ -42,6 +43,11 @@ class TestSummary {
         for test in tests {
             print("-> \(test.summaryRef?.id ?? "") \(String(describing: test.name)) \(String(describing: test.identifier)) \(test.testStatus)")
             print("  \(String(describing: test.activitySummariesCount)) \(String(describing: test.failureSummariesCount)) \(String(describing: test.performanceMetricsCount))")
+            if let testID = test.summaryRef?.id {
+                if let testSummary = result.getActionTestSummary(id: testID) {
+                    testDetails.append(testSummary)
+                }
+            }
         }
         
         successfulTests = tests.filter { $0.testStatus == "Success" }

--- a/xcresultkittest/xcresultkittest/TestSummary.swift
+++ b/xcresultkittest/xcresultkittest/TestSummary.swift
@@ -13,6 +13,8 @@ class TestSummary {
     var successfulTests: [ActionTestMetadata] = []
     var failedTests: [ActionTestMetadata] = []
     var skippedTests: [ActionTestMetadata] = []
+    var expectedFailureTests: [ActionTestMetadata] = []
+    var failureMessages: [TestFailureIssueSummary] = []
     
     func gatherSummary(from result: XCResultFile) {
         
@@ -39,10 +41,15 @@ class TestSummary {
 
         for test in tests {
             print("-> \(test.summaryRef?.id ?? "") \(String(describing: test.name)) \(String(describing: test.identifier)) \(test.testStatus)")
+            print("  \(String(describing: test.activitySummariesCount)) \(String(describing: test.failureSummariesCount)) \(String(describing: test.performanceMetricsCount))")
         }
         
         successfulTests = tests.filter { $0.testStatus == "Success" }
-        failedTests = tests.filter { $0.testStatus != "Success" }
+        failedTests = tests.filter { $0.testStatus == "Failure" }
+        skippedTests = tests.filter { $0.testStatus == "Skipped" }
+        expectedFailureTests = tests.filter { $0.testStatus == "Expected Failure"}
+        
+        failureMessages = invocationRecord.issues.testFailureSummaries
     }
     
     private func gatherTests(summaries: [ActionTestPlanRunSummary]) -> [ActionTestMetadata] {
@@ -85,10 +92,24 @@ class TestSummary {
         }
 
         file.writeLine(" ")
+        file.writeLine("## Expected Failure Tests")
+        file.writeLine(" ")
+        for test in expectedFailureTests {
+            file.writeLine("- \(String(describing: test.identifier)) \(test.duration ?? 0)s")
+        }
+
+        file.writeLine(" ")
         file.writeLine("## Skipped Tests")
         file.writeLine(" ")
         for test in skippedTests {
             file.writeLine("- \(String(describing: test.identifier)) \(test.duration ?? 0)s")
+        }
+        
+        file.writeLine(" ")
+        file.writeLine("## Failure Messages")
+        file.writeLine(" ")
+        for issue in failureMessages {
+            file.writeLine("- \(issue.testCaseName) \(issue.issueType) \(issue.message)")
         }
     }
 }

--- a/xcresultkittest/xcresultkittest/XCResultKitTest.swift
+++ b/xcresultkittest/xcresultkittest/XCResultKitTest.swift
@@ -38,7 +38,8 @@ struct MainApp {
                      platform: "iOS Simulator,name=iPhone 13",
                      expectedSuccessfulTests: 108,
                      expectedFailedTests: 0,
-                     expectedSkippedTests: 0
+                     expectedSkippedTests: 0,
+                     expectedExpectedFailedTests: 0
                     ),
             TestInfo(name: "XCTestExamples",
                      repoURL: URL(string: "git@github.com:davidahouse/XCTestExamples.git")!,
@@ -47,9 +48,10 @@ struct MainApp {
                      scheme: "XCTestExamples",
                      configuration: nil,
                      platform: "iOS Simulator,name=iPhone 13",
-                     expectedSuccessfulTests: 6,
+                     expectedSuccessfulTests: 8,
                      expectedFailedTests: 2,
-                     expectedSkippedTests: 1)
+                     expectedSkippedTests: 1,
+                     expectedExpectedFailedTests: 1)
         ]
         
         print("--- Found \(tests.count) tests to execute ---")

--- a/xcresultkittest/xcresultkittest/XCResultKitTest.swift
+++ b/xcresultkittest/xcresultkittest/XCResultKitTest.swift
@@ -39,7 +39,8 @@ struct MainApp {
                      expectedSuccessfulTests: 108,
                      expectedFailedTests: 0,
                      expectedSkippedTests: 0,
-                     expectedExpectedFailedTests: 0
+                     expectedExpectedFailedTests: 0,
+                     expectedAttachments: 212
                     ),
             TestInfo(name: "XCTestExamples",
                      repoURL: URL(string: "git@github.com:davidahouse/XCTestExamples.git")!,
@@ -51,7 +52,9 @@ struct MainApp {
                      expectedSuccessfulTests: 8,
                      expectedFailedTests: 2,
                      expectedSkippedTests: 1,
-                     expectedExpectedFailedTests: 1)
+                     expectedExpectedFailedTests: 1,
+                     expectedAttachments: 4
+                    )
         ]
         
         print("--- Found \(tests.count) tests to execute ---")


### PR DESCRIPTION
This PR adds a check for the # of expected attachments. This uses the API in XCResultKit that gathers additional information about a specific test, which includes the details about the attachment.